### PR TITLE
Switch to system-wide systemd services. Add restart mechanism for services.

### DIFF
--- a/hacksport/problem.py
+++ b/hacksport/problem.py
@@ -183,8 +183,7 @@ class Service(Challenge):
 
     def service(self):
         return {"Type":"simple",
-                "ExecStart":"/bin/bash -c \"cd {}; {}\"".format(
-                    self.directory, self.start_cmd)
+                "ExecStart":"/bin/bash -c \"{}\"".format(self.start_cmd)
                }
 
 class Remote(Service):


### PR DESCRIPTION
This PR converts problem service files from systemd-user to normal systemd services. These system-wide services use the target `shell_manager.target`, so we can still maintain our services by looking in `/etc/systemd/system/shell_manager.target.wants/`. This Fixes #4.

Additionally, this PR adds a restart mechanism for our problem services. This Fixes #5.