### PR TITLE
Fixed service starting on reboot; Improved problem redeployment

### DIFF
--- a/config/shell_manager.target
+++ b/config/shell_manager.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=CTF Shell Manager
+Requires=multi-user.target
+WantedBy=multi-user.target

--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -4,7 +4,7 @@ Problem deployment.
 
 PROBLEM_FILES_DIR = "problem_files"
 STATIC_FILE_ROOT = "static"
-SYSTEMD_SERVICE_PATH = "/lib/systemd/system/"
+SYSTEMD_SERVICE_PATH = "/etc/systemd/system/"
 
 # will be set to the configuration module during deployment
 deploy_config = None
@@ -326,7 +326,9 @@ def install_user_service(service_file):
     service_path = os.path.join(SYSTEMD_SERVICE_PATH, service_name)
     shutil.copy2(service_file, service_path)
 
-    execute("systemctl enable {0}; systemctl restart {0};".format(service_name), timeout=60)
+    execute(["systemctl", "daemon-reload"])
+    execute(["systemctl", "enable", service_name])
+    execute(["systemctl", "restart", service_name])
 
 def generate_instance(problem_object, problem_directory, instance_number, deployment_directory=None):
     """

--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -326,9 +326,9 @@ def install_user_service(service_file):
     service_path = os.path.join(SYSTEMD_SERVICE_PATH, service_name)
     shutil.copy2(service_file, service_path)
 
-    execute(["systemctl", "daemon-reload"])
-    execute(["systemctl", "enable", service_name])
-    execute(["systemctl", "restart", service_name])
+    execute(["systemctl", "daemon-reload"], timeout=60)
+    execute(["systemctl", "enable", service_name], timeout=60)
+    execute(["systemctl", "restart", service_name], timeout=60)
 
 def generate_instance(problem_object, problem_directory, instance_number, deployment_directory=None):
     """

--- a/hacksport/status.py
+++ b/hacksport/status.py
@@ -115,7 +115,7 @@ def status(args, config):
                 status["connection"] = True
             except ConnectionRefusedError as e:
                 pass
-        result = execute("sudo su -l {} bash -c 'systemctl --user is-failed {}'".format(instance["user"], instance["service"]), allow_error=True)
+        result = execute(["systemctl", "is-failed", instance["service"]], allow_error=True)
         status["service"] = result.return_code == 1
 
         if status["port"] is not None and not status["connection"]:

--- a/install.sh
+++ b/install.sh
@@ -48,3 +48,6 @@ sysctl -p
 hostname shell
 echo "shell" > /etc/hostname
 echo -e "127.0.0.1\tshell" >> /etc/hosts
+
+# make shell_manager.target services run on reboot
+sudo systemctl add-wants default.target shell_manager.target

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
     data_files=[("/opt/hacksports/", ['config/config.py']),
                 ("/lib/security/", ['config/pam_auth.py']),
                 ("/etc/nginx/sites-enabled/", ['config/shell-nginx']),
+                ("/etc/systemd/system/", ['config/shell_manager.target']),
                 ("/opt/hacksports/shellinabox/", ['config/ShellInABox.js',
                                                   'config/shellinabox_cron',
                                                   'config/deploy_shellinabox.sh'])],


### PR DESCRIPTION
This PR fixes #15 by adding a `shell_manager.target` file and making `default.target` want it. This results in all services that are WantedBy shell_manager to be started on reboot.

Additionally, I added a `systemctl daemon-reload` before deploying the new service. In the case of a redeployment, this causes systemd to reload the service file before starting it.

EDIT: I also updated the status call to not user `systemctl --user` anymore.