### PR TITLE
Fix Port Re-assignment Bug

### DIFF
--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -55,7 +55,7 @@ def give_port():
         port = port_random.randint(0, 65535)
         if port not in context["config"].BANNED_PORTS:
             owner, instance = context["port_map"].get(port, (None, None))
-            if owner is None or (owner is context["problem"] and instance is context["instance"]):
+            if owner is None or (owner == context["problem"] and instance == context["instance"]):
                 context["port_map"][port] = (context["problem"], context["instance"])
                 return port
 
@@ -517,6 +517,7 @@ def deploy_problem(problem_directory, instances=1, test=False, deployment_direct
             "description": problem.description,
             "flag": problem.flag,
             "iid": iid,
+            "instance_number": instance_number,
             "files": [f.to_dict() for f in problem.files]
         }
 
@@ -565,7 +566,7 @@ def deploy_problems(args, config):
     for path, problem in get_all_problems().items():
         for instance in get_all_problem_instances(path):
             if "port" in instance:
-                port_map[instance["port"]] = (problem["name"], instance["iid"])
+                port_map[instance["port"]] = (problem["name"], instance["instance_number"])
 
     lock_file = join(HACKSPORTS_ROOT, "deploy.lock")
     if os.path.isfile(lock_file):


### PR DESCRIPTION
This fixes #19.

This bug was a result of two things:
* We only stored the `iid` in the output json, so we were not correctly identifying instances.
* We used `is` for string comparison of the problem name, which does not work as I expected.