### PR TITLE
Removing iids from Shell Manager Deployment.

### DIFF
--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -508,14 +508,12 @@ def deploy_problem(problem_directory, instances=1, test=False, deployment_direct
 
         unique = problem_object["name"] + problem_object["author"] + str(instance_number) + deploy_config.DEPLOY_SECRET
 
-        iid = md5(unique.encode("utf-8")).hexdigest()
         deployment_info = {
             "user": problem.user,
             "service": os.path.basename(instance["service_file"]),
             "server": problem.server,
             "description": problem.description,
             "flag": problem.flag,
-            "iid": iid,
             "instance_number": instance_number,
             "files": [f.to_dict() for f in problem.files]
         }

--- a/hacksport/status.py
+++ b/hacksport/status.py
@@ -101,7 +101,7 @@ def status(args, config):
 
     def get_instance_status(instance):
         status = {
-            "iid": instance["iid"],
+            "instance_number": instance["instance_number"],
             "port": instance["port"] if "port" in instance else None,
             "flag": instance["flag"]
         }
@@ -142,7 +142,7 @@ def status(args, config):
 
         if args.all:
             for instance in problem["instances"]:
-                pprint("   - Instance ID: {}".format(instance["iid"]))
+                pprint("   - Instance {}".format(instance["instance_number"]))
                 pprint("       flag: {}".format(instance["flag"]))
                 pprint("       port: {}".format(instance["port"]))
                 pprint("       service: {}".format("active" if instance["service"] else "failed"))


### PR DESCRIPTION
We want to be able to disassociate instances from a particular deployment secret. We can achieve this by letting the web api deal with iid assignment. 