### PR TITLE
Use uwsgi Instead of gunicorn

### DIFF
--- a/hacksport/problem.py
+++ b/hacksport/problem.py
@@ -221,7 +221,7 @@ class FlaskApp(Service):
         assert os.path.isfile(self.app_file), "module must exist"
 
         self.service_files = [File(self.app_file)]
-        self.start_cmd = "gunicorn --bind 0.0.0.0:{} -w 1 {}".format(self.port, self.app)
+        self.start_cmd = "uwsgi --http 0.0.0.0:{} -w {}".format(self.port, self.app)
 
 class PHPApp(Service):
     """

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['spur', 'openssh-wrapper', "werkzeug", "jinja2", "pytest", "psutil", "flask", "gunicorn"],
+    install_requires=['spur', 'openssh-wrapper', "werkzeug", "jinja2", "pytest", "psutil", "flask", "uwsgi"],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This is a minor change in how we deploy FlaskApps.
uwsgi is a bit more performant than gunicorn, so for large scale deployments this change will make quite a difference in memory usage.

For reference, with 100 instances of a flask challenge running uwsgi used 1.4 GB while gunicorn used 2.2 GB.