### PR TITLE
Fix Deployed Files Bug

### DIFF
--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -536,7 +536,7 @@ def deploy_problem(problem_directory, instances=[0], test=False, deployment_dire
             "description": problem.description,
             "flag": problem.flag,
             "instance_number": instance_number,
-            "files": [f.to_dict() for f in problem.files]
+            "files": [f.to_dict() for f in instance["files"]]
         }
 
         if isinstance(problem, Service):


### PR DESCRIPTION
The deployed json files stores which files belong to the file and their ownership / permission information. The code that produced this files list referenced `problem.files` which didn't always include all of the files (due to the inheritance stuff).
However, the instance returned from `generate_instance` has a `files` entry that stores all files of all types, which we can use to populate this entry in the deployed json.