### PR TITLE
Switch to Systemd Socket Activation

### DIFF
--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -535,7 +535,7 @@ def deploy_problem(problem_directory, instances=[0], test=False, deployment_dire
 
     Args:
         problem_directory: The directory storing the problem
-        instances: The number of instances to deploy. Defaults to 1.
+        instances: The list of instances to deploy. Defaults to [0]
         test: Whether the instances are test instances or not. Defaults to False.
         deployment_directory: If not None, the challenge will be deployed here instead of their home directory
     """
@@ -630,7 +630,7 @@ def deploy_problem(problem_directory, instances=[0], test=False, deployment_dire
 
         logger.debug("The instance deployment information can be found at '%s'.", instance_info_path)
 
-    logger.info("Problem '%s' deployed successfully.", problem_object["name"])
+    logger.info("Problem instances %s were successfully deployed for '%s'.", instances, problem_object["name"])
 
 def deploy_problems(args, config):
     """ Main entrypoint for problem deployment """
@@ -668,7 +668,7 @@ def deploy_problems(args, config):
                 else:
                     logger.error("Could not find bundle at '%s'.", bundle_path)
                     raise FatalException
-        problem_namess = bundle_problems
+        problem_names = bundle_problems
 
     # before deploying problems, load in port_map and already_deployed instances
     already_deployed = {}
@@ -745,12 +745,9 @@ def remove_instances(path, instance_list):
             execute(["systemctl", "disable", service], timeout=60)
             os.remove(join(SYSTEMD_SERVICE_PATH, service))
 
-            shutil.rmtree(directory)
-            os.remove(deployment_json_path)
-
-
             logger.debug("...Removing deployment directory '%s'.", directory)
             shutil.rmtree(directory)
+            os.remove(deployment_json_path)
 
             logger.debug("...Removing problem user '%s'.", user)
             execute(["userdel", user])

--- a/hacksport/problem.py
+++ b/hacksport/problem.py
@@ -202,8 +202,7 @@ class Remote(Service):
         self.service_files = [ExecutableFile(self.program_name)]
 
         program_path = os.path.join(self.directory, self.program_name)
-        self.start_cmd = "socat tcp-listen:{},fork,reuseaddr EXEC:{}".format(
-                self.port, program_path)
+        self.start_cmd = "{}".format(program_path)
 
 class FlaskApp(Service):
     """
@@ -221,7 +220,7 @@ class FlaskApp(Service):
         assert os.path.isfile(self.app_file), "module must exist"
 
         self.service_files = [File(self.app_file)]
-        self.start_cmd = "uwsgi --http 0.0.0.0:{} -w {}".format(self.port, self.app)
+        self.start_cmd = "uwsgi --protocol=http --plugin python3 -w {} --logto /dev/null".format(self.app)
 
 class PHPApp(Service):
     """
@@ -236,4 +235,4 @@ class PHPApp(Service):
         """
 
         web_root = os.path.join(self.directory, self.php_root)
-        self.start_cmd = "php -S 0.0.0.0:{} -t {}".format(self.port, web_root)
+        self.start_cmd = "uwsgi --protocol=http --plugin php --force-cwd {0} --http-socket-modifier1 14 --php-index index.html --php-index index.php --check-static {0} --static-skip-ext php --logto /dev/null".format(web_root)

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['spur', 'openssh-wrapper', "werkzeug", "jinja2", "pytest", "psutil", "flask", "uwsgi"],
+    install_requires=['spur', 'openssh-wrapper', "werkzeug", "jinja2", "pytest", "psutil", "flask"],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This change switches all of our services away from socat and over to systemd socket activation. The web challenges now all use uwsgi, which can inherit sockets from systemd.

This change relies on [PR #29](https://github.com/picoCTF/picoCTF-platform/pull/29) on picoCTF-Platform.