### PR TITLE
Support for toggling ASLR

### DIFF
--- a/extra/no_aslr_wrapper.c
+++ b/extra/no_aslr_wrapper.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+#include <sys/personality.h>
+
+int main(int argc, char *argv[], char *envp[]) {
+    personality(ADDR_NO_RANDOMIZE);
+    argv[0] = BINARY_PATH;
+    execve(argv[0], argv, envp);
+}

--- a/hacksport/problem_templates.py
+++ b/hacksport/problem_templates.py
@@ -7,7 +7,8 @@ from copy import copy
 import os
 
 def CompiledBinary(makefile=None, compiler="gcc", sources=None, binary_name=None,
-                        is_32_bit=True, executable_stack=True, no_stack_protector=True, compiler_flags=copy([]),
+                        is_32_bit=True, executable_stack=True, no_stack_protector=True,
+                        aslr=False, compiler_flags=copy([]),
                         flag_file=None, static_flag=None, share_source=False, remote=False):
     """
     Creates a challenge for a compiled binary. User must specify either a makefile
@@ -29,6 +30,8 @@ def CompiledBinary(makefile=None, compiler="gcc", sources=None, binary_name=None
                           Defaults to True.
         no_stack_protector: Specifies if the output binary should opt out of stack canaries. Only works nicely with gcc as the compiler.
                             Defaults to True.
+        aslr: Specifies if the output binary should have aslr or not. Only used if the challenge is remote.
+                            Defaults to False.
         compiler_flags: The list of any additional compiler flags to be passed. Defaults to [].
         flag_file: The name of the flag file. If it does not exist, it will be created. Defaults to flag.txt
         static_flag: A string containing the static flag. If specified, the flag generation will always return this. Defaults to None.
@@ -57,6 +60,8 @@ def CompiledBinary(makefile=None, compiler="gcc", sources=None, binary_name=None
 
     class Problem(*base_classes):
         files = copy([])
+
+        remove_aslr = not aslr
 
         if share_source:
             files = copy([File(source) for source in sources])

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ setup(
                 ("/etc/nginx/sites-enabled/", ['config/shell-nginx']),
                 ("/etc/systemd/system/", ['config/shell_manager.target']),
                 ("/opt/hacksports/shellinabox/", ['config/ShellInABox.js']),
-                ("/opt/hacksports/config/", ['config/securebashrc'])],
+                ("/opt/hacksports/config/", ['config/securebashrc']),
+                ("/opt/hacksports/extra/", ['extra/no_aslr_wrapper.c'])],
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow

--- a/shell_manager/util.py
+++ b/shell_manager/util.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 # the root of the hacksports local store
 HACKSPORTS_ROOT = "/opt/hacksports/"
 PROBLEM_ROOT = join(HACKSPORTS_ROOT, "sources")
+EXTRA_ROOT = join(HACKSPORTS_ROOT, "extra")
 STAGING_ROOT = join(HACKSPORTS_ROOT, "staging")
 DEPLOYED_ROOT = join(HACKSPORTS_ROOT, "deployed")
 BUNDLE_ROOT = join(HACKSPORTS_ROOT, "bundles")


### PR DESCRIPTION
This addresses issue #54. With the addition of [PR #31](https://github.com/picoCTF/picoCTF-platform/pull/31) from platform, ASLR will be enabled system wide. If services wish to opt out of ASLR, we will now compile a wrapper to execute the service without address randomization.