### PR TITLE
Ignore the templating step for a set of files

### DIFF
--- a/hacksport/deploy.py
+++ b/hacksport/deploy.py
@@ -304,8 +304,7 @@ def template_file(in_file_path, out_file_path, **kwargs):
     with open(out_file_path, "w") as f:
         f.write(output)
 
-def template_staging_directory(staging_directory, problem, dont_template_files = ["problem.json", "challenge.py"],
-                                                           dont_template_directories = ["templates"]):
+def template_staging_directory(staging_directory, problem):
     """
     Templates every file in the staging directory recursively other than
     problem.json and challenge.py.
@@ -313,11 +312,13 @@ def template_staging_directory(staging_directory, problem, dont_template_files =
     Args:
         staging_directory: The path of the staging directory
         problem: The problem object
-        dont_template_files: The list of files not to template. Defaults to ["problem.json", "challenge.py"]
-        dont_template_directories: The list of files not to recurse into. Defaults to ["templates"]
     """
 
     # prepend the staging directory to all
+    dont_template = copy(problem.dont_template) + ["problem.json", "challenge.py", "templates"]
+
+    dont_template_files = list(filter(isfile, dont_template))
+    dont_template_directories = list(filter(isdir, dont_template))
     dont_template_directories = [join(staging_directory, directory) for directory in dont_template_directories]
 
     for root, dirnames, filenames in os.walk(staging_directory):

--- a/hacksport/problem.py
+++ b/hacksport/problem.py
@@ -81,6 +81,7 @@ class Challenge(metaclass=ABCMeta):
     """
 
     files = []
+    dont_template = []
 
     def generate_flag(self, random):
         """

--- a/shell_manager/package.py
+++ b/shell_manager/package.py
@@ -137,7 +137,7 @@ def find_problems(problem_path):
     problem_paths = []
 
     for root, _, files in os.walk(problem_path):
-        if "problem.json" in files:
+        if "problem.json" in files and "__staging" not in root:
             problem_paths.append(root)
 
     return problem_paths


### PR DESCRIPTION
This closes #9 and fixed a bug where failing to package a problem would leave an orphaned `__staging` directory that would contain a problem.json and be interpreted as another problem.