### PR TITLE
Instances are no longer deployed to home directories.

### DIFF
--- a/hacksport/operations.py
+++ b/hacksport/operations.py
@@ -46,24 +46,13 @@ def execute(cmd, timeout=60, **kwargs):
 
     return process.wait_for_result()
 
-def create_user(username, home_directory_root="/home/"):
+def create_user(username):
     """
-    Creates a user with the given username
+    Creates a user account with the given username
 
     Args:
         username: the username to create
-        home_directory_root: the parent directory to create the
-                             home directory in. Defaults to /home/
 
-    Returns:
-        The new user's home directory
     """
 
-    home_directory = path.join(home_directory_root, username)
-
-    if not path.isdir(home_directory):
-        makedirs(home_directory)
-
-    execute(["useradd", "-s", "/bin/bash", "-m", "-d", home_directory, username])
-
-    return home_directory
+    execute(["useradd", "-s", "/bin/bash", username])

--- a/hacksport/status.py
+++ b/hacksport/status.py
@@ -9,6 +9,9 @@ import os
 import shutil
 import socket
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_all_problems():
     """ Returns a dictionary of name:object mappings """
@@ -81,10 +84,12 @@ def clean(args, config):
 
     # remove staging directories
     if os.path.isdir(STAGING_ROOT):
+        logger.info("Removing the staging directories")
         shutil.rmtree(STAGING_ROOT)
 
     # remove lock file
     if os.path.isfile(lock_file):
+        logger.info("Removing the stale lock file")
         os.remove(lock_file)
 
     #TODO: potentially perform more cleaning

--- a/shell_manager/config.py
+++ b/shell_manager/config.py
@@ -17,8 +17,8 @@ DEFAULT_USER = "hacksports"
 # specifies.
 WEB_ROOT = "/usr/share/nginx/html/"
 
-# the root of the home directories for the problem instances
-HOME_DIRECTORY_ROOT = "/home/problems/"
+# the root of the problem directories for the instances
+PROBLEM_DIRECTORY_ROOT = "/problems/"
 
 # "obfuscate" problem directory names
 OBFUSCATE_PROBLEM_DIRECTORIES = False

--- a/shell_manager/run.py
+++ b/shell_manager/run.py
@@ -65,8 +65,8 @@ def main():
     bundle_parser.set_defaults(func=bundle_problems)
 
     deploy_parser = subparsers.add_parser("deploy", help="problem deployment")
-    deploy_parser.add_argument("-n", "--num-instances", type=int, default=1, help="number of instances to generate.")
-    deploy_parser.add_argument("-i", "--instance", type=int, default=None, help="particular instance to generate.")
+    deploy_parser.add_argument("-n", "--num-instances", type=int, default=1, help="number of instances to generate (numbers 0 through n-1).")
+    deploy_parser.add_argument("-i", "--instances", action="append", type=int, help="particular instance(s) to generate.")
     deploy_parser.add_argument("-d", "--dry", action="store_true", help="don't make persistent changes.")
     deploy_parser.add_argument("-r", "--redeploy", action="store_true", help="redeploy instances that have already been deployed")
     deploy_parser.add_argument("-s", "--secret", action="store", type=str, help="use a different deployment secret for this invocation.")
@@ -76,8 +76,8 @@ def main():
     deploy_parser.set_defaults(func=deploy_problems)
 
     undeploy_parser = subparsers.add_parser("undeploy", help="problem undeployment. cannot guarantee full removal of problem files")
-    undeploy_parser.add_argument("-n", "--num-instances", type=int, default=1, help="number of instances to undeploy.")
-    undeploy_parser.add_argument("-i", "--instance", type=int, default=None, help="particular instance to undeploy.")
+    undeploy_parser.add_argument("-n", "--num-instances", type=int, default=1, help="number of instances to undeploy (numbers 0 through n-1).")
+    undeploy_parser.add_argument("-i", "--instances", action="append", type=int, help="particular instance(s) to generate.")
     undeploy_parser.add_argument("-b", "--bundle", action="store_true", help="specify a bundle of problems to undeploy.")
     undeploy_parser.add_argument("problem_paths", nargs="*", type=str, help="paths to problems.")
     undeploy_parser.set_defaults(func=undeploy_problems)

--- a/tests/problems/compiled_sources/problem.json
+++ b/tests/problems/compiled_sources/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "The flag is totally not: {{flag}}",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/problems/compiled_sources_url/problem.json
+++ b/tests/problems/compiled_sources_url/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "The flag is totally not: {{flag}}. And it definitely isn't available at {{url_for('flag.txt')}}",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/problems/local_compiled1/problem.json
+++ b/tests/problems/local_compiled1/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "Test",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/problems/local_compiled2/problem.json
+++ b/tests/problems/local_compiled2/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "Test",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/problems/remote_compiled1/problem.json
+++ b/tests/problems/remote_compiled1/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "Test",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/problems/remote_compiled_makefile_template/problem.json
+++ b/tests/problems/remote_compiled_makefile_template/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "Your lucky number is {{lucky}}! Service is running at {{server}}:{{port}}",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/problems/remote_no_compile/problem.json
+++ b/tests/problems/remote_no_compile/problem.json
@@ -3,5 +3,6 @@
   "score": 50,
   "author": "test",
   "description": "Service is running at {{server}}:{{port}}",
-  "category": "Binary"
+  "category": "Binary",
+  "hints": []
 }

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -1,6 +1,6 @@
 import hacksport.deploy
 from hacksport.deploy import deploy_problem
-from config import config
+from shell_manager import config
 
 from os.path import join, realpath, dirname
 
@@ -12,7 +12,8 @@ class Config:
     WEB_ROOT = "/usr/share/ngninx/html"
     BANNED_PORTS = config.BANNED_PORTS
     DEFAULT_USER = config.DEFAULT_USER
-    HOME_DIRECTORY_ROOT = config.HOME_DIRECTORY_ROOT
+    PROBLEM_DIRECTORY_ROOT = config.PROBLEM_DIRECTORY_ROOT
+    OBFUSCATE_PROBLEM_DIRECTORIES = config.OBFUSCATE_PROBLEM_DIRECTORIES
 
 hacksport.deploy.deploy_config = Config()
 


### PR DESCRIPTION
Configuration flag `HOME_DIRECTORY_ROOT` has been renamed to `PROBLEM_DIRECTORY_ROOT`. If this change is installed into any existing setups, you will have to update this field name.

This PR also contains various UX improvements:

* You can now supply multiple `-i [instance_num]` arguments to a single deployment
* Added more logging statements.
* `PROBLEM_DIRECTORY_ROOT` is set `o-r` upon creation
* Staging directory names are prefixed with their problem name and instance number to aid in locating the correct one
* Staging directories are deleted by default unless the debug flag was provided. `shell_manager clean` can still clean up these lingering staging directories.

This closes #29.

EDIT:
The test suite has been out of date for a while now. I updated it so that it works with the changes introduced in this PR.