### PR TITLE
Made Configuration File JSON

### DIFF
--- a/config/pam_auth.py
+++ b/config/pam_auth.py
@@ -6,15 +6,15 @@ import json
 import subprocess
 import time
 
-from imp import load_source
 from os.path import join
 
 DEFAULT_USER    = "nobody"
 HACKSPORTS_ROOT = "/opt/hacksports/"
 COMPETITORS_GROUP = "competitors"
 
-config = load_source("config", join(HACKSPORTS_ROOT, "config.py"))
-SERVER = config.WEB_SERVER
+config_file = join(HACKSPORTS_ROOT, "config.json")
+config = json.loads(open(config_file).read())
+SERVER = config["web_server"]
 TIMEOUT=5
 
 pamh = None

--- a/shell_manager/config.py
+++ b/shell_manager/config.py
@@ -12,6 +12,8 @@ from shell_manager.util import get_config, write_configuration_file, write_globa
 logger = logging.getLogger(__name__)
 
 def port_range_to_str(port_range):
+    if port_range["start"] == port_range["end"]:
+        return str(port_range["start"])
     return "%d-%d" % (port_range["start"], port_range["end"])
 
 def banned_ports_to_str(banned_ports):
@@ -28,15 +30,22 @@ def print_configuration(args, global_config):
         try:
             config = get_config(args.file)
         except FileNotFoundError:
-            log.fatal("Could not find configuration file '%s'", args.file)
+            logger.fatal("Could not find configuration file '%s'", args.file)
             raise FatalException
 
-    print("Configuration options:")
+    if args.json:
+        print("Configuration options (in JSON):")
+    else:
+        print("Configuration options (pretty printed):")
+
     for option, value in config.items():
-        if option == "banned_ports":
-            value_string = banned_ports_to_str(value)
+        if args.json:
+            value_string = json.dumps(value)
         else:
-            value_string = repr(value)
+            if option == "banned_ports":
+                value_string = banned_ports_to_str(value)
+            else:
+                value_string = repr(value)
 
         print("  %s = %s" % (option.ljust(50), value_string))
 
@@ -51,7 +60,7 @@ def set_configuration_option(args, global_config):
         try:
             config = get_config(args.file)
         except FileNotFoundError:
-            log.fatal("Could not find configuration file '%s'", args.file)
+            logger.fatal("Could not find configuration file '%s'", args.file)
             raise FatalException
 
     field = args.field

--- a/shell_manager/config.py
+++ b/shell_manager/config.py
@@ -1,28 +1,26 @@
-from os.path import join
+{
+    "deploy_secret": "qwertyuiop",
 
-# secret used for deterministic deployment
-DEPLOY_SECRET = "qwertyuiop"
+    "hostname": "127.0.0.1",
 
-# the externally accessable address of this server
-HOSTNAME = "127.0.0.1"
+    "web_server": "http://127.0.0.1",
 
-# the url of the web server
-WEB_SERVER = "http://127.0.0.1"
+    "default_user": "hacksports",
 
-# the default username for files to be owned by
-DEFAULT_USER = "hacksports"
+    "web_root": "/usr/share/nginx/html/",
 
-# the root of the web server running to serve static files
-# make sure this is consistent with what config/shell.nginx
-# specifies.
-WEB_ROOT = "/usr/share/nginx/html/"
+    "problem_directory_root": "/problems/",
 
-# the root of the problem directories for the instances
-PROBLEM_DIRECTORY_ROOT = "/problems/"
+    "obfuscate_problem_directories": false,
 
-# "obfuscate" problem directory names
-OBFUSCATE_PROBLEM_DIRECTORIES = False
-
-# list of ports that should not be assigned to any instances
-# this bans the first ports 0-999 and 4242 for shellinaboxd
-BANNED_PORTS = list(range(1000))+[4242]
+    "banned_ports": [
+        {
+            "start": 0,
+            "end": 1000
+        },
+        {
+            "start": 4242,
+            "end": 4242
+        }
+    ]
+}

--- a/shell_manager/config.py
+++ b/shell_manager/config.py
@@ -1,26 +1,92 @@
-{
-    "deploy_secret": "qwertyuiop",
+"""
+Utilities for dealing with configuration commands
+"""
 
-    "hostname": "127.0.0.1",
+import json
+import os
+import logging
 
-    "web_server": "http://127.0.0.1",
+from shell_manager.util import get_config, write_configuration_file, write_global_configuration, \
+                               place_default_config, FatalException
 
-    "default_user": "hacksports",
+logger = logging.getLogger(__name__)
 
-    "web_root": "/usr/share/nginx/html/",
+def port_range_to_str(port_range):
+    return "%d-%d" % (port_range["start"], port_range["end"])
 
-    "problem_directory_root": "/problems/",
+def banned_ports_to_str(banned_ports):
+    return "[" + ", ".join(map(port_range_to_str, banned_ports)) + "]"
 
-    "obfuscate_problem_directories": false,
+def print_configuration(args, global_config):
+    """
+    Entry point for config subcommand
+    """
 
-    "banned_ports": [
-        {
-            "start": 0,
-            "end": 1000
-        },
-        {
-            "start": 4242,
-            "end": 4242
-        }
-    ]
-}
+    if args.file == None:
+        config = global_config
+    else:
+        try:
+            config = get_config(args.file)
+        except FileNotFoundError:
+            log.fatal("Could not find configuration file '%s'", args.file)
+            raise FatalException
+
+    print("Configuration options:")
+    for option, value in config.items():
+        if option == "banned_ports":
+            value_string = banned_ports_to_str(value)
+        else:
+            value_string = repr(value)
+
+        print("  %s = %s" % (option.ljust(50), value_string))
+
+def set_configuration_option(args, global_config):
+    """
+    Entry point for config set subcommand
+    """
+
+    if args.file == None:
+        config = global_config
+    else:
+        try:
+            config = get_config(args.file)
+        except FileNotFoundError:
+            log.fatal("Could not find configuration file '%s'", args.file)
+            raise FatalException
+
+    field = args.field
+    value = args.value
+    if args.json:
+        try:
+            value = json.loads(args.value)
+        except Exception as e:
+            logger.fatal("Couldn't parse value as JSON")
+            raise FatalException
+
+    if field in config and type(config[field]) != type(value) and not args.allow_type_change:
+        logger.fatal("Tried to change type of '%s' from '%s' to '%s'", field, type(config[field]), type(value))
+        logger.fatal("Try adding --json and supplying the value as json.")
+        logger.fatal("If changing the type is desired, add the --allow-type-change option")
+        raise FatalException
+
+    config[field] = value
+
+    if args.file:
+      write_configuration_file(args.file, config)
+    else:
+      write_global_configuration(config)
+
+    logger.info("Set {} = {}".format(field, value))
+
+def new_configuration_file(args, global_config):
+    """
+    Entry point for config new subcommand
+    """
+
+    for path in args.files:
+        if not args.overwrite and os.path.exists(path):
+            logger.warning("'%s' already exists. Not placing new configuration.", path)
+            continue
+
+        place_default_config(path)
+        logger.info("Default configuration file '%s' was created", path)

--- a/shell_manager/run.py
+++ b/shell_manager/run.py
@@ -6,6 +6,7 @@ Shell Manager -- Tools for deploying and packaging problems.
 
 import logging, coloredlogs
 import shell_manager
+import json
 
 from argparse import ArgumentParser
 from shell_manager.package import problem_builder
@@ -20,8 +21,6 @@ from os.path import join, dirname
 from os import sep, chmod
 
 from shutil import copy2
-
-from imp import load_source
 
 coloredlogs.DEFAULT_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 coloredlogs.DEFAULT_DATE_FORMAT = "%H:%M:%S"
@@ -107,17 +106,17 @@ def main():
     if args.debug:
         coloredlogs.set_level(logging.DEBUG)
     try:
-        config_path = join(HACKSPORTS_ROOT, "config.py")
+        config_path = join(HACKSPORTS_ROOT, "config.json")
         try:
-            config = load_source("config", config_path)
+            config = get_config(config_path)
         except PermissionError:
             logger.error("You must run shell_manager with sudo.")
             raise FatalException
         except FileNotFoundError:
-            default_config_path = join(dirname(shell_manager.__file__), "config.py")
+            default_config_path = join(dirname(shell_manager.__file__), "config.json")
             copy2(default_config_path, HACKSPORTS_ROOT)
             chmod(config_path, 0o640)
-            logger.info("There is no config.py in '%s'. One has been created for you. Please edit it accordingly.", HACKSPORTS_ROOT)
+            logger.info("There is no config.json in '%s'. One has been created for you. Please edit it accordingly.", HACKSPORTS_ROOT)
             raise FatalException
 
         #Call the default function

--- a/shell_manager/run.py
+++ b/shell_manager/run.py
@@ -93,6 +93,7 @@ def main():
 
     config_parser = subparsers.add_parser("config", help="View or modify configuration options")
     config_parser.add_argument("-f", "--file", type=str, default=None, help="Which configuration file to access. If none is provided, the system wide configuration file will be used.")
+    config_parser.add_argument("-j", "--json", action="store_true", default=False, help="Whether to display the configuration options in JSON form or pretty printed. Defaults to False.")
     config_parser.set_defaults(func=print_configuration)
     config_subparsers = config_parser.add_subparsers()
 

--- a/shell_manager/util.py
+++ b/shell_manager/util.py
@@ -269,19 +269,14 @@ def get_bundle(bundle_path):
 
     return bundle
 
-def get_config(path):
+def verify_config(config_object):
     """
-    Retrieve a configuration object from the given path
+    Verifies the given configuration dict against the config_schema and the port_range_schema
+    Raise FatalException if failed.
 
     Args:
-        path: the full path to the json file
-
-    Returns:
-        A python object containing the fields within
+        config_object: The configuration options in a dict
     """
-
-    with open(path) as f:
-        config_object = json.loads(f.read())
 
     try:
         config_schema(config_object)
@@ -301,6 +296,22 @@ def get_config(path):
         except AssertionError as e:
             logger.critical("Invalid port range: (%d -> %d)", port_range["start"], port_range["end"])
             raise FatalException
+
+def get_config(path):
+    """
+    Retrieve a configuration object from the given path
+
+    Args:
+        path: the full path to the json file
+
+    Returns:
+        A python object containing the fields within
+    """
+
+    with open(path) as f:
+        config_object = json.loads(f.read())
+
+    verify_config(config_object)
 
     config = ConfigDict()
     for key, value in config_object.items():
@@ -323,6 +334,8 @@ def write_configuration_file(path, config_dict):
         path: the path of the output JSON file
         config_dict: the configuration dictionary
     """
+
+    verify_config(config_dict)
 
     with open(path, "w") as f:
         json_data = json.dumps(config_dict, sort_keys=True,

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -6,16 +6,8 @@ from os.path import join, realpath, dirname
 
 PATH = dirname(realpath(__file__))
 
-class Config:
-    DEPLOY_SECRET = "Af9h3mc"
-    HOSTNAME = "super.shell.server"
-    WEB_ROOT = "/usr/share/ngninx/html"
-    BANNED_PORTS = config.BANNED_PORTS
-    DEFAULT_USER = config.DEFAULT_USER
-    PROBLEM_DIRECTORY_ROOT = config.PROBLEM_DIRECTORY_ROOT
-    OBFUSCATE_PROBLEM_DIRECTORIES = config.OBFUSCATE_PROBLEM_DIRECTORIES
-
-hacksport.deploy.deploy_config = Config()
+config_path = join(PATH, "../shell_manager/config.json")
+hacksport.deploy.deploy_config = get_config(config_path)
 
 class TestProblems:
     """

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -1,13 +1,12 @@
 import hacksport.deploy
 from hacksport.deploy import deploy_problem
-from shell_manager import config
+from shell_manager.util import default_config
 
 from os.path import join, realpath, dirname
 
 PATH = dirname(realpath(__file__))
 
-config_path = join(PATH, "../shell_manager/config.json")
-hacksport.deploy.deploy_config = get_config(config_path)
+hacksport.deploy.deploy_config = default_config
 
 class TestProblems:
     """


### PR DESCRIPTION
This PR resolves #67.

The configuration file is now `/opt/hacksports/config.json`, but this is mostly hidden from the user. 
Users will no longer have to edit the configuration file directly.

Configuration options can be shown from the command line:
`shell_manager config` (values pretty printed)
`shell_manager config --json` (values shown as JSON).

Configuration fields can be modified from the command line as well.
`shell_manager config set -f [field] -v [value]` (set a string value)
`shell_manager config set -f [field] -v [value as json] --json` (set the value as json)

Trying to change the type of a field will raise an exception unless the `--allow-type-change` option is provided.

So far, every default configuration option is a string, with the exception of `banned_ports`. This option is specified using a list of `port_range` objects:

```
"banned_ports": [
    {
        "start": 0,
        "end": 1000
    },
    {
        "start": 4242,
        "end": 4242
     }
]
```
The above definition bans ports 0 through 1000 as well as port 4242.

Along with the default, required configuration options, users can now add their own configuration options. All configuration options specified are passed into the Problem classes as fields (similar to how `server` and `default_user` were previously). This means that problem classes can now access system-wide configuration options, which may turn out being useful for complicated setup processes.


New default configuration files can be created using `shell_manager config new [output_file]`.
The `shell_manager config` subcommand takes an optional `-f` or `--file` option, which specifies which configuration file to view or modify. This allows configuration files to be created and modified without being in `/opt/hacksports/config.json`.


The tests are also up-to-date with this change. They were even useful in fixing a few bugs for once!